### PR TITLE
fix(core): unify ID types to string and fix category/event display is…

### DIFF
--- a/core/application/UseCase/Category/DeleteCategory.php
+++ b/core/application/UseCase/Category/DeleteCategory.php
@@ -13,7 +13,7 @@ class DeleteCategory
         $this->repository = $repository;
     }
 
-    public function execute(int $id): bool
+    public function execute(string $id): bool
     {
         return $this->repository->delete($id);
     }

--- a/core/application/UseCase/Category/GetCategoryById.php
+++ b/core/application/UseCase/Category/GetCategoryById.php
@@ -14,7 +14,7 @@ class GetCategoryById
         $this->repository = $repository;
     }
 
-    public function execute(int $id): ?Category
+    public function execute(string $id): ?Category
     {
         return $this->repository->findById($id);
     }

--- a/core/application/UseCase/Category/UpdateCategory.php
+++ b/core/application/UseCase/Category/UpdateCategory.php
@@ -14,7 +14,7 @@ class UpdateCategory
         $this->repository = $repository;
     }
 
-    public function execute(int $id, array $data): ?Category
+    public function execute(string $id, array $data): ?Category
     {
         return $this->repository->update($id, $data);
     }

--- a/core/application/UseCase/Event/DeleteEvent.php
+++ b/core/application/UseCase/Event/DeleteEvent.php
@@ -14,7 +14,7 @@ class DeleteEvent
         $this->eventRepository = $eventRepository;
     }
 
-    public function execute(int $eventId): void
+    public function execute(string $eventId): void
     {
         $deleted = $this->eventRepository->delete($eventId);
 

--- a/core/application/UseCase/Event/GetEventById.php
+++ b/core/application/UseCase/Event/GetEventById.php
@@ -9,7 +9,7 @@ class GetEventById
 {
     public function __construct(private EventRepositoryInterface $eventRepository) {}
 
-    public function execute(int $id)
+    public function execute(string $id)
     {
         $event = $this->eventRepository->findById($id);
 

--- a/core/application/UseCase/Event/GetEventsByCategory.php
+++ b/core/application/UseCase/Event/GetEventsByCategory.php
@@ -13,7 +13,7 @@ class GetEventsByCategory
         $this->eventRepository = $eventRepository;
     }
 
-    public function execute(int $categoryId): array
+    public function execute(string $categoryId): array
     {
         return $this->eventRepository->getEventByCateg($categoryId);
     }

--- a/core/application/UseCase/Image/AddImageToEvent.php
+++ b/core/application/UseCase/Image/AddImageToEvent.php
@@ -9,7 +9,7 @@ class AddImageToEvent
 {
     public function __construct(private ImageRepositoryInterface $imageRepository) {}
 
-    public function execute(int $eventId, string $imagePath): void
+    public function execute(string $eventId, string $imagePath): void
     {
         try {
             $this->imageRepository->addImageToEvent($eventId, $imagePath);

--- a/core/application/UseCase/Image/GetImagesByEventId.php
+++ b/core/application/UseCase/Image/GetImagesByEventId.php
@@ -9,7 +9,7 @@ class GetImagesByEventId
 {
     public function __construct(private ImageRepositoryInterface $imageRepository) {}
 
-    public function execute(int $eventId): array
+    public function execute(string $eventId): array
     {
         try {
             return $this->imageRepository->getImagesByEventId($eventId);

--- a/core/application/interfaces/EventRepositoryInterface.php
+++ b/core/application/interfaces/EventRepositoryInterface.php
@@ -9,16 +9,16 @@ interface EventRepositoryInterface
 {
     public function getAll(): \Illuminate\Database\Eloquent\Collection;
 
-    public function getById(int $id): ?Event;
+    public function getById(string $id): ?Event;
 
     public function create(array $data): Event;
 
-    public function update(int $id, array $data): ?Event;
+    public function update(string $id, array $data): ?Event;
 
-    public function delete(int $id): bool;
+    public function delete(string $id): bool;
 
     public function getEventByPeriodFilter(string $startDate, string $endDate): Collection;
 
-    public function getEventByCateg(int $categoryId): array;
+    public function getEventByCateg(string $categoryId): array;
 
 }

--- a/core/application/services/CategoryService.php
+++ b/core/application/services/CategoryService.php
@@ -32,7 +32,7 @@ class CategoryService
         return $this->getAllCategories->execute();
     }
 
-    public function getById(int $id): ?Category
+    public function getById(string $id): ?Category
     {
         return $this->getCategoryById->execute($id);
     }
@@ -42,12 +42,12 @@ class CategoryService
         return $this->createCategory->execute($data);
     }
 
-    public function update(int $id, array $data): ?Category
+    public function update(string $id, array $data): ?Category
     {
         return $this->updateCategory->execute($id, $data);
     }
 
-    public function delete(int $id): bool
+    public function delete(string $id): bool
     {
         return $this->deleteCategory->execute($id);
     }

--- a/core/application/services/EventService.php
+++ b/core/application/services/EventService.php
@@ -60,7 +60,7 @@ class EventService
         return $this->getPublishedEvent->execute();
     }
 
-    public function getEventById(int $id): Event
+    public function getEventById(string $id): Event
     {
         return $this->getEventById->execute($id);
     }
@@ -70,7 +70,7 @@ class EventService
         return $this->createEvent->execute($data);
     }
 
-    public function deleteEvent(int $id): bool
+    public function deleteEvent(string $id): bool
     {
         $this->deleteEvent->execute($id);
         return true;
@@ -80,7 +80,7 @@ class EventService
     {
         return $this->getEventByPeriodFilter->execute($startDate, $endDate);
     }
-    public function getEventsByCategory(int $categoryId): array
+    public function getEventsByCategory(string $categoryId): array
     {
         return $this->getEventsByCategory->execute($categoryId);
     }
@@ -95,12 +95,9 @@ class EventService
         return $this->getAllEvent->execute('date-asc');
     }
 
-    public function getEventsByCategorySortedByDateAsc(int $categoryId): array
+    public function getEventsByCategorySortedByDateAsc(string $categoryId): array
     {
         return $this->getEventsByCategory->execute($categoryId, 'date-asc');
 
     }
-
-
 }
-

--- a/core/application/services/ImageService.php
+++ b/core/application/services/ImageService.php
@@ -12,7 +12,7 @@ class ImageService
         private GetImagesByEventId $getImagesByEventId
     ) {}
 
-    public function addImage(int $eventId, string $imagePath): void
+    public function addImage(string $eventId, string $imagePath): void
     {
         $this->addImageToEvent->execute($eventId, $imagePath);
     }

--- a/infra/persistence/Eloquent/EventRepository.php
+++ b/infra/persistence/Eloquent/EventRepository.php
@@ -30,7 +30,7 @@ class EventRepository implements EventRepositoryInterface
      * @param int $id
      * @return Event|null
      */
-    public function getById(int $id): ?Event
+    public function getById(string $id): ?Event
     {
         return Event::with(['category', 'author', 'images'])->find($id);
     }
@@ -54,7 +54,7 @@ class EventRepository implements EventRepositoryInterface
      * @param array $data
      * @return Event|null
      */
-    public function update(int $id, array $data): ?Event
+    public function update(string $id, array $data): ?Event
     {
         $event = $this->getById($id);
 
@@ -74,7 +74,7 @@ class EventRepository implements EventRepositoryInterface
      * @param int $id
      * @return bool
      */
-    public function delete(int $id): bool
+    public function delete(string $id): bool
     {
         $event = $this->getById($id);
 
@@ -91,7 +91,7 @@ class EventRepository implements EventRepositoryInterface
             ->whereBetween('start_date', [$startDate, $endDate])
             ->get();
     }
-    public function getEventByCateg(int $categoryId): array
+    public function getEventByCateg(string $categoryId): array
     {
         $events = Event::with('category')
             ->where('category_id', $categoryId)
@@ -108,7 +108,7 @@ class EventRepository implements EventRepositoryInterface
         })->toArray();
     }
 
-    public function findById(int $id): ?Event
+    public function findById(string $id): ?Event
     {
         return Event::find($id);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,7 +6,8 @@ use Slim\Routing\RouteCollectorProxy;
 
 use LaChaudiere\webui\actions\Category\CreateCategoryAction;
 use LaChaudiere\webui\actions\Category\DeleteCategoryAction;
-use LaChaudiere\webui\actions\Category\GetCategoriesAction;
+use LaChaudiere\webui\actions\Category\GetCategoryAction;
+use LaChaudiere\webui\actions\Category\GetAllCategoryAction;
 use LaChaudiere\webui\actions\Event\DeleteEventAction;
 use LaChaudiere\webui\actions\Event\GetAllEventsAction;
 use LaChaudiere\webui\actions\Event\GetEventsByCategAction;
@@ -26,7 +27,7 @@ return function (App $app) {
 
         // Routes pour les catégories
         $group->group('/categories', function (RouteCollectorProxy $group) {
-            $group->get('', GetCategoriesAction::class);
+            $group->get('', GetAllCategoryAction::class);
             $group->get('/create/{id}', CreateCategoryAction::class);
             $group->get('/delete/{id}', DeleteCategoryAction::class);
             $group->get('/{id}', GetEventsByCategoryIdAction::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ use LaChaudiere\webui\actions\Auth\UpdateUserAction;
 use LaChaudiere\webui\actions\Event\ListEventAction;
 use LaChaudiere\webui\actions\Category\CreateCategoryAction;
 use LaChaudiere\webui\actions\Category\DeleteCategoryAction;
-use LaChaudiere\webui\actions\Category\GetCategoriesAction;
+use LaChaudiere\webui\actions\Category\GetCategoryAction;
 use LaChaudiere\webui\actions\Category\ShowCreateCategoryFormAction;
 use LaChaudiere\webui\actions\HomePageAction;
 use LaChaudiere\webui\actions\Event\CreateEventFormAction;
@@ -52,7 +52,7 @@ return function (App $app) {
 
         // Routes catégories
         $group->group('/categories', function (RouteCollectorProxy $group) {
-            $group->get('', GetCategoriesAction::class);
+            $group->get('', GetCategoryAction::class);
             $group->get('/create', ShowCreateCategoryFormAction::class);
             $group->post('/create', CreateCategoryAction::class);
             $group->delete('/{id}', DeleteCategoryAction::class);

--- a/webui/actions/Category/GetAllCategoryAction.php
+++ b/webui/actions/Category/GetAllCategoryAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaChaudiere\webui\actions\Category;
+
+use LaChaudiere\core\application\services\CategoryService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class GetAllCategoryAction
+{
+    private CategoryService $categoryService;
+
+    public function __construct(CategoryService $categoryService)
+    {
+        $this->categoryService = $categoryService;
+    }
+
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $categories = $this->categoryService->getAll();
+
+        $response->getBody()->write(json_encode([
+            'success' => true,
+            'data' => $categories,
+            'count' => count($categories)
+        ]));
+
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(200);
+    }
+}

--- a/webui/actions/Category/GetCategoryAction.php
+++ b/webui/actions/Category/GetCategoryAction.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
 
-class GetCategoriesAction
+class GetCategoryAction
 {
     private CategoryService $categoryService;
 

--- a/webui/actions/Event/ListEventsAction.php
+++ b/webui/actions/Event/ListEventsAction.php
@@ -32,7 +32,7 @@ class ListEventsAction
         $categories = $this->categoryService->getAll();
 
         if ($categoryId) {
-            $events = $this->eventService->getEventsByCategorySortedByDateAsc((int)$categoryId);
+            $events = $this->eventService->getEventsByCategorySortedByDateAsc($categoryId); 
         } else {
             $events = $this->eventService->getAllEventsSortedByDateAsc();
         }


### PR DESCRIPTION
…sues

- Changed all entity and service ID types from int to string (UUID consistency)
- Fixed broken /api/categories route due to incorrect type handling
- Resolved missing category names in event list view by eager-loading category relation